### PR TITLE
INT-1056: Remove unnecessary spread operator

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -403,7 +403,7 @@ async function getIcon(iconUrl, options) {
     },
     encoding: null
   });
-  log.info({ response }, 'getIcon Response');
+
   return `data:${response.headers['content-type']};base64,${Buffer.from(response.body, 'binary').toString('base64')}`;
 }
 

--- a/integration.js
+++ b/integration.js
@@ -42,7 +42,7 @@ function startup(logger) {
     new Promise((resolve, reject) => {
       requestWithDefaults(requestOptions, (err, res, body) => {
         if (err) return reject(err);
-        resolve({ ...res, body });
+        resolve(res);
       });
     });
 }
@@ -403,6 +403,7 @@ async function getIcon(iconUrl, options) {
     },
     encoding: null
   });
+  log.info({ response }, 'getIcon Response');
   return `data:${response.headers['content-type']};base64,${Buffer.from(response.body, 'binary').toString('base64')}`;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Jira",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Jira",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "main": "./integration.js",
   "description": "Jira Issue Search",
   "private": true,


### PR DESCRIPTION
Remove an unnecessary spread operator as this was not working on the v5 server (possibly node 18 related).

The spread operator isn't needed here since the `res` object already contains the `body` object.  On node18 the use of the spread operator was causing the response object to not contain a headers property.